### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "hubot": ">=2.5.4",
-    "lodash": "1.3.1"
+    "hubot": ">=2.5.4"
   },
   "license": "WTFPL"
 }


### PR DESCRIPTION
This version of hubot-mock-adapter removed the code which uses lodash, so might as well remove it from package.json.